### PR TITLE
Make truly PHP 5.3 compatible.

### DIFF
--- a/src/Msurguy/Honeypot/HoneypotServiceProvider.php
+++ b/src/Msurguy/Honeypot/HoneypotServiceProvider.php
@@ -57,7 +57,7 @@ class HoneypotServiceProvider extends ServiceProvider {
     */
     public function provides()
     {
-        return ['honeypot'];
+        return array('honeypot');
     }
 
     /**


### PR DESCRIPTION
Use of PHP 5.4's array shorthand makes the composer.json requirement an issue. Everyone should be using at least 5.4 but there's nothing in here that couldn't work on 5.3 so this makes it work like it should on legacy versions.
