### PR TITLE
Simplified honeypot HTML constructing and improved test

### DIFF
--- a/src/Msurguy/Honeypot/Honeypot.php
+++ b/src/Msurguy/Honeypot/Honeypot.php
@@ -1,23 +1,35 @@
 <?php namespace Msurguy\Honeypot;
 
-use View;
 use Crypt;
 
 class Honeypot {
 
     /**
-     * Function to render the HTML of the hidden honeypot form
+     * Get the honey pot form HTML
+     * @param  string $honey_name
+     * @param  string $honey_time
+     * @return string
      */
     public function getFormHTML($honey_name, $honey_time)
     {
         // Encrypt the current time
-        $honey_time_encrypted = Crypt::encrypt(time());
+        $honey_time_encrypted = $this->getEncryptedTime();
 
-        return View::make("honeypot::fields", array(
-            'honey_name'           => $honey_name,
-            'honey_time'           => $honey_time,
-            'honey_time_encrypted' => $honey_time_encrypted
-        ));
+        $html = '<div id="' . $honey_name . '_wrap" style="display:none;">\r\n' .
+                    '<input name="' . $honey_name . '" type="text" value="" id="' . $honey_name . '"/>\r\n' .
+                    '<input name="' . $honey_time . '" type="text" value="' . $honey_time_encrypted . '"/>\r\n' .
+                '</div>';
+
+        return $html;
+    }
+
+    /**
+     * Get encrypted time
+     * @return string
+     */
+    public function getEncryptedTime()
+    {
+        return Crypt::encrypt(time());
     }
 
 }

--- a/src/Msurguy/Honeypot/HoneypotServiceProvider.php
+++ b/src/Msurguy/Honeypot/HoneypotServiceProvider.php
@@ -49,7 +49,6 @@ class HoneypotServiceProvider extends ServiceProvider {
         }
         elseif ($this->isLaravelVersion(5))
         {
-            $this->loadViewsFrom(__DIR__ . '/../../views/', 'honeypot');
             $this->loadTranslationsFrom(__DIR__ . '/../../lang', 'honeypot');
         }
 

--- a/src/views/fields.blade.php
+++ b/src/views/fields.blade.php
@@ -1,4 +1,0 @@
-<div id="<?php echo $honey_name ?>_wrap" style="display:none;">
-    <input id="<?php echo $honey_name ?>" name="<?php echo $honey_name ?>" type="text" value="">  
-    <input name="<?php echo $honey_time ?>" type="hidden" value="<?php echo $honey_time_encrypted ?>">
-</div>

--- a/tests/HoneypotTest.php
+++ b/tests/HoneypotTest.php
@@ -1,65 +1,32 @@
 <?php namespace Msurguy\Tests;
 
 use Mockery;
-use Msurguy\Honeypot\Honeypot;
-use Illuminate\Support\Facades\Facade;
 
 class HoneypotTest extends \PHPUnit_Framework_TestCase {
 
     private $honeypot;
-    private $crypt;
-    private $view;
 
     public function setUp()
     {
-        $this->honeypot = new Honeypot;
-        $this->crypt = Mockery::mock();
-        $this->view  = Mockery::mock();
-
-        $app = $this->getFacadeApplication();
-
-        Facade::setFacadeApplication($app);
+        $this->honeypot = Mockery::mock('Msurguy\Honeypot\Honeypot[getEncryptedTime]');
+        $this->honeypot->shouldReceive('getEncryptedTime')->once()->andReturn('ENCRYPTED_TIME');
     }
 
     public function tearDown()
     {
         Mockery::close();
-        Facade::setFacadeApplication(null);
-        Facade::clearResolvedInstances();
     }
 
-    private function getFacadeApplication()
+    public function test_get_honeypot_form_html()
     {
-        return array(
-            'encrypter' => $this->crypt,
-            'view' => $this->view
-        );
-    }
+        $actualHtml = $this->honeypot->getFormHTML('honey_name', 'honey_time');
+        $expectedHtml = '' .
+            '<div id="honey_name_wrap" style="display:none;">\r\n' .
+                '<input name="honey_name" type="text" value="" id="honey_name"/>\r\n' .
+                '<input name="honey_time" type="text" value="ENCRYPTED_TIME"/>\r\n' .
+            '</div>';
 
-    /** @test */
-    public function it_assigns_the_values_to_the_view()
-    {
-        $this->crypt->shouldReceive('encrypt')
-                    ->with(1000)->once()
-                    ->andReturn('encrypted');
-
-        $viewVariables = array(
-            'honey_name' => 'honey_name',
-            'honey_time' => 'honey_time',
-            'honey_time_encrypted' => 'encrypted'
-        );
-
-        $this->view->shouldReceive('make')
-                   ->with('honeypot::fields', $viewVariables)->once()
-                   ->andReturn('view');
-
-        $result = $this->honeypot->getFormHtml('honey_name', 'honey_time');
-
-        $this->assertEquals(
-            'view',
-            $result,
-            'The values should be assigned to the view.'
-        );
+        $this->assertEquals($actualHtml, $expectedHtml);
     }
 
 }


### PR DESCRIPTION
For such a simple form, it's probably a bit overkill using Laravel to render the view. This simplifies this and also the tests associated with it (and improves explicitly testing the correct output for the form). Plus this helps make the package more framework agnostic -- technically this whole package could not even need Laravel at all with a bit of tweaking, and correct dependency injecting (like the Crypt class.)