### PR TITLE
Remove formbuilder macro, use the facade. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,19 +21,23 @@ Next, add this line to 'providers' section of the app config file in `app/config
 
     'Msurguy\Honeypot\HoneypotServiceProvider',
 
+Add the honeypot facade:
+
+    'Honeypot' => 'Msurguy\Honeypot\HoneypotFacade'
+
 At this point the package is installed and you can use it as follows.
 
 ## Usage :
 
-Add the hidden DIV containing honeypot fields to your form by inserting `Form::honeypot` macro like this: 
+Add the honeypot catcher to your form by inserting `Honeypot::generate(..)` like this: 
 
     {{ Form::open('contact') }}
         ...
-        {{ Form::honeypot('my_name', 'my_time') }}
+        {{ Honeypot::generate('my_name', 'my_time') }}
         ...
     {{ Form::close() }}
 
-When the page containing `Form::honeypot` macro is rendered, the following HTML markup will be present (my_time field will contain an encrypted timestamp):
+The `generate` method will output the following HTML markup (`my_time` field will contain an encrypted timestamp):
     
     <div id="my_name_wrap" style="display:none;">
         <input name="my_name" type="text" value="" id="my_name">

--- a/src/Msurguy/Honeypot/Honeypot.php
+++ b/src/Msurguy/Honeypot/Honeypot.php
@@ -5,12 +5,12 @@ use Crypt;
 class Honeypot {
 
     /**
-     * Get the honey pot form HTML
+     * Generate a new honeypot and return the form HTML
      * @param  string $honey_name
      * @param  string $honey_time
      * @return string
      */
-    public function getFormHTML($honey_name, $honey_time)
+    public function generate($honey_name, $honey_time)
     {
         // Encrypt the current time
         $honey_time_encrypted = $this->getEncryptedTime();

--- a/src/Msurguy/Honeypot/HoneypotServiceProvider.php
+++ b/src/Msurguy/Honeypot/HoneypotServiceProvider.php
@@ -1,6 +1,5 @@
 <?php namespace Msurguy\Honeypot;
 
-use Illuminate\Html\FormBuilder;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
@@ -52,9 +51,6 @@ class HoneypotServiceProvider extends ServiceProvider {
             // Add honeypot and honeytime custom validation rules
             $validator->extend('honeypot', 'Msurguy\Honeypot\HoneypotValidator@validateHoneypot', $translator->get('honeypot::validation.honeypot'));
             $validator->extend('honeytime', 'Msurguy\Honeypot\HoneypotValidator@validateHoneytime', $translator->get('honeypot::validation.honeytime'));
-
-            // Register the honeypot form macros
-            $this->registerFormMacro($this->isLaravelVersion(['4.0', '4.1']) ? $app['form'] : null);
         });
     }
 
@@ -66,30 +62,6 @@ class HoneypotServiceProvider extends ServiceProvider {
     public function provides()
     {
         return array('honeypot');
-    }
-
-    /**
-    * Register the honeypot form macro
-    *
-    * @param  Illuminate\Html\FormBuilder|null $form
-    * @return void
-    */
-    public function registerFormMacro(FormBuilder $form = null)
-    {
-        $honeypotMacro = function($honey_name, $honey_time) {
-            $honeypot = new Honeypot();
-            return $honeypot->getFormHTML($honey_name, $honey_time);
-        };
-
-        // Add a custom honeypot macro to Laravel's form
-        if ($form)
-        {
-            $form->macro('honeypot', $honeypotMacro);
-        }
-        else
-        {
-            FormBuilder::macro('honeypot', $honeypotMacro);
-        }
     }
 
     /**


### PR DESCRIPTION
@msurguy how do you feel about this one? Of course a breaking change so would need a major version bump but I think currently a lot of issues spawn from usage of the `macro` on FormBuilder. These issues range from supporting legacy Laravel < 4.2, newer Laravel >= 4.2.. and now that `illuminate/html` has been deprecated it's been replaced with another package called Laravel Collective which runs under a different namespace but is essentially the new `illluminate/html`.

That's a lot to support and keep up with when all it's doing is just adding a macro which isn't really worth it imo. Doing `Honeypot::getFormHtml(...)` vs `Form::honeypot(...)` isn't really much of a difference.

As this is a breaking change, I've also added in this commit a rename of the method `getFormHtml` to simply `generate` -- it's possibly a nice time to make the change as read's nicer in it's usage:

{{ Honeypot::getFormHtml() }}
{{ Honeypot::generate() }}

Let me know what you think :smile: 