### PR TITLE
Removed escaped printing of text

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,19 @@ At this point the package is installed and you can use it as follows.
 
 Add the honeypot catcher to your form by inserting `Honeypot::generate(..)` like this: 
 
+Laravel 5 & above:
     {!! Form::open('contact') !!}
         ...
         {!! Honeypot::generate('my_name', 'my_time') !!}
         ...
     {!! Form::close() !!}
+    
+Other Laravel versions:
+    {{ Form::open('contact') }}
+        ...
+        {{ Honeypot::generate('my_name', 'my_time') }}
+        ...
+    {{ Form::close() }}
 
 The `generate` method will output the following HTML markup (`my_time` field will contain an encrypted timestamp):
     

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ At this point the package is installed and you can use it as follows.
 
 Add the honeypot catcher to your form by inserting `Honeypot::generate(..)` like this: 
 
-    {{ Form::open('contact') }}
+    {!! Form::open('contact') !!}
         ...
-        {{ Honeypot::generate('my_name', 'my_time') }}
+        {!! Honeypot::generate('my_name', 'my_time') !!}
         ...
-    {{ Form::close() }}
+    {!! Form::close() !!}
 
 The `generate` method will output the following HTML markup (`my_time` field will contain an encrypted timestamp):
     

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ At this point the package is installed and you can use it as follows.
 Add the honeypot catcher to your form by inserting `Honeypot::generate(..)` like this: 
 
 Laravel 5 & above:
+
     {!! Form::open('contact') !!}
         ...
         {!! Honeypot::generate('my_name', 'my_time') !!}
@@ -39,6 +40,7 @@ Laravel 5 & above:
     {!! Form::close() !!}
     
 Other Laravel versions:
+
     {{ Form::open('contact') }}
         ...
         {{ Honeypot::generate('my_name', 'my_time') }}


### PR DESCRIPTION
Using {{ }} in Laravel 5 escapes the HTML and printings the HTML to screen.