### PR TITLE
Replace L4 Exception with generic Exception to support both L4 and L5

### DIFF
--- a/src/Msurguy/Honeypot/Honeypot.php
+++ b/src/Msurguy/Honeypot/Honeypot.php
@@ -101,7 +101,7 @@ class Honeypot {
     	try {
             return Crypt::decrypt($time);
     	}
-    	catch (\Illuminate\Encryption\DecryptException $exception)
+    	catch (\Exception $exception)
         {
             return null;
         }


### PR DESCRIPTION
The class name for the DecryptException has changed in L5. Instead of: 
`\Illuminate\Encryption\DecryptException`

it is now:
`\Illuminate\Contracts\Encryption\DecryptException`

So in order to support both L4 and L5 integrations I suggest to change the catch to a generic Exception class.