### PR TITLE
Friends don't let friends use dev-master

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ This package creates a hidden DIV with two fields in it, honeypot field (like "m
 
 ## Installation:
 
-In your terminal type : `composer require msurguy/honeypot` and provide "dev-master" as the version of the package. Or open up composer.json and add the following line under "require":
+In your terminal type : `composer require msurguy/honeypot`. Or open up composer.json and add the following line under "require":
 
     {
         "require": {
-            "msurguy/honeypot": "dev-master"
+            "msurguy/honeypot": "^1.0"
         }
     }
 


### PR DESCRIPTION
Requiring the stable version is probably the best way to go for most users.

Thank you for this package! 👍 