### PR TITLE
Fix Crypt use statement

### DIFF
--- a/src/Msurguy/Honeypot/Honeypot.php
+++ b/src/Msurguy/Honeypot/Honeypot.php
@@ -1,6 +1,6 @@
 <?php namespace Msurguy\Honeypot;
 
-use Crypt;
+use Illuminate\Support\Facades\Crypt;
 
 class Honeypot {
 


### PR DESCRIPTION
The current use statement throws a “Class "Crypt" not found” when using `Honeypot::generate()`.